### PR TITLE
Update code snippet styles

### DIFF
--- a/assets/design-system/styles.css
+++ b/assets/design-system/styles.css
@@ -167,6 +167,11 @@ code {
 	color: #b30000;
 }
 
+pre code {
+	tab-size: 4;
+	white-space: pre;
+}
+
 kbd {
 	background-color: #eaeaea;
 	border: solid 1px #ccc;


### PR DESCRIPTION
During recent updates to the W3C Design System, I have found issues with the visual presentation of example code snippets.

This pull request aims to Improve legibility of code snippets, by specifying the tab size and how to handle white space for more consistent handling of indentation.